### PR TITLE
Lex invalid text as barewords instead of errors

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -496,7 +496,7 @@ func (l *Lexer) lexWordTail(next consumerFunc) consumerFunc {
 }
 
 func (l *Lexer) lexBecomeWord(r rune) (Token, consumerFunc, error) {
-	if r > 0 {
+	if r >= 0 {
 		l.buffer(r, r)
 	}
 	return noToken, l.lexWordTail(l.lexSegmentTail), nil


### PR DESCRIPTION
This has some benefits for humans but also means there's higher
responsibility from the POV of anything consuming the AST to validate
its inputs, which... seems reasonable but this is in a separate branch
because I'm still on the fence about the change. The benefit here is
you can do things like 10.0.0.0/8, which would previously be lexed
initially as a decimal and then fail on the second '.'. It also opens
the way for allowing some of the reserved characters at the beginning
of barewords, like '#'.