### PR TITLE
Add AST walking function / interface

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    threshold: 6
+    project: yes
+    patch: yes
+    changes: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - '1.10'
 
 script:
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  - go test -v -coverprofile=coverage.txt -covermode=atomic
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/ast.go
+++ b/ast.go
@@ -63,6 +63,7 @@ type Document struct {
 
 func (*Document) astnode() {}
 
+// Nodes returns the child nodes of the document.
 func (d *Document) Nodes() []Node {
 	return d.Children
 }
@@ -99,6 +100,7 @@ type Statement struct {
 	EndTok Token
 }
 
+// Parameters returns the parameters the statement holds.
 func (s *Statement) Parameters() []ExprNode {
 	return s.Params
 }
@@ -158,10 +160,12 @@ type Section struct {
 	EndTok   Token
 }
 
+// Nodes returns the child nodes of the section.
 func (s *Section) Nodes() []Node {
 	return s.Children
 }
 
+// Parameters returns the parameters the section holds.
 func (s *Section) Parameters() []ExprNode {
 	return s.Params
 }

--- a/ast.go
+++ b/ast.go
@@ -55,9 +55,12 @@ type parentNode interface {
 	addChild(node Node)
 }
 
-// Document is the root of a codf document -- it is functionally similar to a Section, but is
-// unnamed and has no parameters.
+// Document is the root of a codf document -- it is functionally similar to a Section, has no
+// parameters.
 type Document struct {
+	// Name is usually a filename assigned by the user. It is not assigned by a parser and is
+	// just metadata on the Document.
+	Name     string
 	Children []Node // Sections and Statements that make up the Document.
 }
 
@@ -408,9 +411,25 @@ func Bool(node Node) (v, ok bool) {
 }
 
 // String returns the value held by node as a string and true.
-// If the node doesn't hold a string, it returns the empty string and false.
+// If the node doesn't hold a string or word, it returns the empty string and false.
 func String(node Node) (str string, ok bool) {
 	str, ok = Value(node).(string)
+	return
+}
+
+// Quote returns the string value of node if and only if node is a quoted string.
+func Quote(node Node) (str string, ok bool) {
+	if lit, isLit := node.(*Literal); isLit && (lit.Tok.Kind == TString || lit.Tok.Kind == TRawString) {
+		str, ok = lit.Value().(string)
+	}
+	return
+}
+
+// Word returns the string value of node if and only if node is a word.
+func Word(node Node) (str string, ok bool) {
+	if lit, isLit := node.(*Literal); isLit && lit.Tok.Kind == TWord {
+		str, ok = lit.Value().(string)
+	}
 	return
 }
 

--- a/ast_test.go
+++ b/ast_test.go
@@ -2,6 +2,56 @@ package codf
 
 import "testing"
 
+func TestStringConversion(t *testing.T) {
+	exprs := mkexprs(
+		mkstr("quoted"),
+		mkrawstr("raw quoted"),
+		mkword("word-string"),
+		mkdec("4.1234"),
+		mkexpr(1234),
+		mkrat(1, 2),
+	)
+
+	check := func(t *testing.T, convert func(Node) (string, bool), expected ...bool) {
+		for i, wantOK := range expected {
+			ex := exprs[i]
+			got, ok := convert(ex)
+			if ok != wantOK {
+				t.Errorf("%d: converting %v returned %t; want %t", i, ex, ok, wantOK)
+				continue
+			} else if !ok {
+				continue
+			}
+
+			want := ex.(*Literal).Value().(string)
+			if got != want {
+				t.Errorf("%d: converting %v returned %q; want %q", i, ex, got, want)
+			}
+		}
+	}
+
+	t.Run("String", func(t *testing.T) {
+		check(t, String,
+			true, true, true,
+			false, false, false,
+		)
+	})
+
+	t.Run("Quote", func(t *testing.T) {
+		check(t, Quote,
+			true, true, false,
+			false, false, false,
+		)
+	})
+
+	t.Run("Word", func(t *testing.T) {
+		check(t, Word,
+			false, false, true,
+			false, false, false,
+		)
+	})
+}
+
 func TestFloat64Conversion(t *testing.T) {
 	wants := mkexprs(
 		mkdec("0.25"),

--- a/gofuzz.go
+++ b/gofuzz.go
@@ -4,6 +4,7 @@ package codf // import "go.spiff.io/codf"
 
 import (
 	"bytes"
+	"fmt"
 )
 
 func Fuzz(b []byte) (rc int) {
@@ -21,4 +22,47 @@ func FuzzLexer(b []byte) (rc int) {
 			return
 		}
 	}
+}
+
+type fuzzWalker struct{}
+
+func (w *fuzzWalker) Statement(st *Statement) error {
+	switch st.Name() {
+	case "server_name",
+		"listen",
+		"proxy_pass",
+		"add_header",
+		"user",
+		"daemon",
+		"log_format",
+		"acces_log",
+		"error_log":
+		return nil
+	default:
+		return fmt.Errorf("invalid statement name: %s", st.Name())
+	}
+}
+
+func (w *fuzzWalker) EnterSection(sec *Section) (Walker, error) {
+	switch sec.Name() {
+	case "http",
+		"server",
+		"location",
+		"upstream",
+		"stream":
+		return w, nil
+	default:
+		return nil, fmt.Errorf("invalid section name: %s", sec.Name())
+	}
+}
+
+func FuzzWalker(b []byte) (rc int) {
+	lex := NewLexer(bytes.NewReader(b))
+	p := NewParser()
+	if err := p.Parse(lex); err != nil {
+		// No panic, but can't use the document
+		return 0
+	}
+	Walk(p.Document(), new(fuzzWalker))
+	return 0
 }

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -11,10 +11,6 @@ import (
 	"time"
 )
 
-// logf is a pointer to the current test's Logf function.
-// Only used for debugging.
-var logf = func(string, ...interface{}) {}
-
 func TestInvalidTokenName(t *testing.T) {
 	const want = "invalid"
 	const tok32 = TokenKind(0xffffffff)
@@ -843,10 +839,4 @@ func TestDurations(t *testing.T) {
 			seq.Run(t, c)
 		})
 	}
-}
-
-func setlogf(t *testing.T) func() {
-	fn := logf
-	logf = t.Logf
-	return func() { logf = fn }
 }

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,13 @@
+package codf
+
+import "testing"
+
+// logf is a pointer to the current test's Logf function.
+// Only used for debugging.
+var logf = func(string, ...interface{}) {}
+
+func setlogf(t *testing.T) func() {
+	temp := logf
+	logf = t.Logf
+	return func() { logf = temp }
+}

--- a/parse_util_test.go
+++ b/parse_util_test.go
@@ -64,6 +64,33 @@ func mkexpr(arg interface{}) ExprNode {
 	panic(fmt.Errorf("unsupported type %T", arg))
 }
 
+func mkstr(s string) *Literal {
+	return &Literal{
+		Tok: Token{
+			Kind:  TString,
+			Value: s,
+		},
+	}
+}
+
+func mkrawstr(s string) *Literal {
+	return &Literal{
+		Tok: Token{
+			Kind:  TRawString,
+			Value: s,
+		},
+	}
+}
+
+func mkword(s string) *Literal {
+	return &Literal{
+		Tok: Token{
+			Kind:  TWord,
+			Value: s,
+		},
+	}
+}
+
 func mkmap(args ...interface{}) *Map {
 	if len(args)%2 == 1 {
 		panic("mkmap must receive arguments in pairs of (string, value); got valueless key")

--- a/parser_test.go
+++ b/parser_test.go
@@ -25,6 +25,12 @@ func mustParse(t *testing.T, in string) *Document {
 	return doc
 }
 
+func mustParseNamed(t *testing.T, name string, in string) *Document {
+	doc := mustParse(t, in)
+	doc.Name = name
+	return doc
+}
+
 func mustNotParse(t *testing.T, in string) *Document {
 	doc, err := parse(in)
 	if err == nil {

--- a/walk.go
+++ b/walk.go
@@ -1,0 +1,127 @@
+package codf
+
+import "fmt"
+
+// Walker is used by Walk to consume statements and sections, recursively, in ParentNodes (sections
+// and documents).
+//
+// Optionally, Walkers may also implement WalkExiter to see receive an ExitSection call when exiting
+// a section.
+type Walker interface {
+	Statement(*Statement) error
+	EnterSection(*Section) (Walker, error)
+}
+
+// WalkExiter is an optional interface implemented for a Walker to have Walk call ExitSection when
+// it has finished consuming all children in a section.
+type WalkExiter interface {
+	Walker
+
+	// ExitSection is called with the parent Walker, the exited node, and its parent node
+	// (either the root document given to Walk or a section).
+	ExitSection(Walker, *Section, ParentNode) error
+}
+
+// Walk walks a codf AST starting with but not including parent.
+// It is assumed that by having the parent, it has already been walked.
+//
+// Walk will call walker.Statement for each statement encountered in parent and walker.EnterSection
+// for each section (and walker.ExitSection if implemented).
+//
+// If walker.EnterSection returns a non-nil Walker, Walk will recursively call Walk with the section
+// and the returned Walker.
+//
+// Walk will return a *WalkError if any error occurs during a walk. The WalkError will contain both
+// the parent and child node that the error occurred for.
+func Walk(parent ParentNode, walker Walker) (err error) {
+	children := append([]Node(nil), parent.Nodes()...)
+reset:
+	for i := 0; i < len(children); i++ {
+		child := children[i]
+		switch child := child.(type) {
+		case *Statement:
+			// Statements are passed verbatim as directives
+			err = walker.Statement(child)
+
+		case *Section:
+			// Sections are entered, walked, and exited -- the sub-Walker is given
+			// a chance to interact with its parent when exiting the section, if it
+			// implemented ConfigExiter.
+			var sub Walker
+			if sub, err = walker.EnterSection(child); err != nil || sub == nil {
+				break
+			}
+			if err = Walk(child, sub); err != nil {
+				break
+			}
+			err = exitWalker(sub, walker, child, parent)
+
+		case *Document:
+			// Merge a non-empty document's children with the current set of children,
+			// discarding children already seen.
+			docNodes := child.Nodes()
+			if n := len(docNodes); n == 0 {
+				continue
+			} else if n < i+1 {
+				children = append(append(children[:0], docNodes...), children[i+1:]...)
+			} else {
+				tail := children[i+1:]
+				children = make([]Node, 0, len(tail)+n)
+				children = append(append(children, docNodes...), tail...)
+			}
+			goto reset
+		}
+
+		if err != nil {
+			return walkErr(parent, child, err)
+		}
+	}
+	return nil
+}
+
+func exitWalker(walker Walker, next Walker, section *Section, parent ParentNode) error {
+	ex, ok := walker.(WalkExiter)
+	if !ok {
+		return nil
+	}
+	return ex.ExitSection(next, section, parent)
+}
+
+// WalkError is an error returned by Walk if an error occurs during a Walk call.
+type WalkError struct {
+	// Context is the ParentNode that Node is a child of.
+	Context ParentNode
+	// Node is the node that was encountered when the error occurred.
+	Node Node
+	// Err is the error that a Walker returned.
+	Err error
+}
+
+func walkErr(ctx ParentNode, node Node, err error) *WalkError {
+	if we, ok := err.(*WalkError); ok {
+		return we
+	}
+	return &WalkError{
+		Context: ctx,
+		Node:    node,
+		Err:     err,
+	}
+}
+
+func (e *WalkError) Error() string {
+	return "[" + e.Node.Token().Start.String() + "] " +
+		contextName(e.Node) + " in " + contextName(e.Context) + ": " + e.Err.Error()
+}
+
+func contextName(node Node) string {
+	switch node := node.(type) {
+	case *Document:
+		return "main"
+	case *Section:
+		return node.Name()
+	case *Statement:
+		return node.Name()
+	default:
+		return fmt.Sprintf("<%v>", node)
+	}
+}

--- a/walk_test.go
+++ b/walk_test.go
@@ -1,0 +1,192 @@
+package codf
+
+import (
+	"fmt"
+	"testing"
+)
+
+type docWalker struct {
+	name       string
+	statements map[string]struct{}
+	sections   map[string]*docWalker
+}
+
+func (d *docWalker) Statement(stmt *Statement) error {
+	logf("STATEMENT: %v", stmt)
+	if _, ok := d.statements[stmt.Name()]; !ok {
+		return fmt.Errorf("invalid statement: %s", stmt.Name())
+	}
+	return nil
+}
+
+func (d *docWalker) EnterSection(sec *Section) (Walker, error) {
+	logf("ENTER: %v", sec.Name())
+	if sub := d.sections[sec.Name()]; sub != nil {
+		return sub, nil
+	}
+	return nil, fmt.Errorf("invalid section: %s", sec.Name())
+}
+
+func (d *docWalker) ExitSection(_ Walker, sec *Section, parent ParentNode) error {
+	logf("EXIT: %v", sec.Name())
+	if sec.Name() != d.name {
+		return fmt.Errorf("ExitSection called with invalid section named %s", sec.Name())
+	}
+	return nil
+}
+
+func sectionWalker(name string, children ...interface{}) *docWalker {
+	w := &docWalker{
+		name:       name,
+		statements: map[string]struct{}{},
+		sections:   map[string]*docWalker{},
+	}
+
+	for _, child := range children {
+		switch child := child.(type) {
+		case *docWalker:
+			w.sections[child.name] = child
+		case string:
+			w.statements[child] = struct{}{}
+		default:
+			panic(fmt.Errorf("invalid walker child type: %T", child))
+		}
+	}
+	return w
+}
+
+func TestWalk(t *testing.T) {
+	defer setlogf(t)()
+	const DocSource = `
+	user http;
+	daemon no;
+
+	http {
+		server {
+			server_name go.spiff.io;
+			listen 80;
+			listen 443 http2 ssl;
+
+			location / {
+				root /var/www/public;
+				index index.html index.htm;
+			}
+		}
+
+		sendfile yes;
+		keepalive_timeout 65s;
+	}
+	`
+	doc := mustParse(t, DocSource)
+	doc.addChild(mustParse(t, ``))
+	doc.addChild(mustParse(t, `
+		worker_processes auto;
+	`))
+	doc.addChild(mustParse(t, `
+		worker_processes 1;
+		user httpd;
+		user www-data;
+		user nobody;
+		daemon yes;
+		daemon true;
+		daemon false;
+	`))
+
+	t.Run("Valid", func(t *testing.T) {
+		defer setlogf(t)()
+		def := sectionWalker("main",
+			"user",
+			"daemon",
+			"worker_processes",
+			sectionWalker("http",
+				"sendfile",
+				"keepalive_timeout",
+
+				sectionWalker("server",
+					"server_name",
+					"listen",
+					sectionWalker("location",
+						"root",
+						"index",
+					),
+				),
+			),
+		)
+
+		if err := Walk(doc, def); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("InvalidNestedSection", func(t *testing.T) {
+		defer setlogf(t)()
+		def := sectionWalker("main",
+			"user",
+			"daemon",
+			"worker_processes",
+			sectionWalker("http",
+				"sendfile",
+			),
+		)
+
+		if err := Walk(doc, def); err == nil {
+			t.Fatal("expected error on server section")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("InvalidNestedStatement", func(t *testing.T) {
+		defer setlogf(t)()
+		def := sectionWalker("main",
+			"user",
+			"daemon",
+			"worker_processes",
+			sectionWalker("http",
+				"sendfile",
+
+				sectionWalker("server",
+					"server_name",
+					"listen",
+					sectionWalker("location",
+						"root",
+						"index",
+					),
+				),
+			),
+		)
+
+		if err := Walk(doc, def); err == nil {
+			t.Fatal("expected error on keepalive_timeout statement")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("InvalidNestedDocument", func(t *testing.T) {
+		defer setlogf(t)()
+		def := sectionWalker("main",
+			"user",
+			"daemon",
+			sectionWalker("http",
+				"sendfile",
+				"keepalive_timeout",
+
+				sectionWalker("server",
+					"server_name",
+					"listen",
+					sectionWalker("location",
+						"root",
+						"index",
+					),
+				),
+			),
+		)
+
+		if err := Walk(doc, def); err == nil {
+			t.Fatal("expected error on worker_processes statement")
+		} else {
+			t.Log(err)
+		}
+	})
+}


### PR DESCRIPTION
Adds a Walk function to recursively traverse the AST in logical pieces, including walking through nested documents. An optional interface for the Walker, WalkMapper, allows mapping nodes before they're passed to the Walker proper.