### PR TITLE
Refactor the Lexer for io.Reader, location names

### DIFF
--- a/_test/simple-file
+++ b/_test/simple-file
@@ -1,0 +1,8 @@
+' Start
+
+statement word;
+
+section "string" {
+}
+
+' End of file

--- a/parser.go
+++ b/parser.go
@@ -67,7 +67,9 @@ func (p *Parser) Parse(tr TokenReader) (err error) {
 		}
 	}()
 
+	var setDocName bool
 	if p.next == nil {
+		setDocName = p.doc.Name == ""
 		p.next = p.beginSegment
 	}
 
@@ -77,6 +79,11 @@ func (p *Parser) Parse(tr TokenReader) (err error) {
 		if err != nil {
 			return err
 		}
+
+		if setDocName {
+			p.doc.Name = tok.Start.Name
+		}
+
 		if p.next, err = p.next(tok); err != nil {
 			return err
 		}


### PR DESCRIPTION
- The Lexer now accepts an io.Reader instead of an io.RuneScanner.
  There are a few reasons for this, but the first one is that it's
  simply easier to use -- almost everyone who passes in an io.Reader
  that isn't an io.RuneReader will probably use a bufio.Reader anyway,
  so the lexer will default to using that when given an io.Reader.

  The second is to make it easier to support e.g., os.File, which has
  a Name method on it that the Lexer can use to assign a name to token
  locations. This will make error messages and so on easier to digest
  (for humans, anyway), since if they allow multi-file configs, it's
  really pretty important to be able to say where an error is. NewLexer
  will, if given an io.Reader with a Name method, wrap it in a buffered
  Reader and keep the name method around from the wrapped io.Reader, so
  the default behavior should be acceptable.

  Third is that io.RuneScanner was no longer a strict requirement to
  begin with. UnreadRune hasn't been used in the lexer for a while (it
  has its own unread method), so the hard requirement is RuneReader.
  Because of the first point, however, it doesn't really make sense to
  not provide a sane default of a bufio.Reader, so now it's easier.

- Location names are supported by way of either a) the default name set
  in the Lexer's Name field. This will be used if, for example, reading
  from an io.Reader without a Name method, or whose Name method returns
  the empty string. The name is assigned for each rune read, so it's
  possible to chain files together and return the current filename
  being read. (This would have to be implemented by someone -- I'm not
  doing it.)

- The Parser sets the Document's name according to the first token it
  sees if it hasn't already been given a name. This makes it a little
  easier to identify the document's source since it doesn't have
  a token of its own to identify itself by.