### PR TITLE
Allow braces & comment runes in barewords

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -99,7 +99,7 @@ func TestParseAST(t *testing.T) {
 		},
 		{
 			Name: "MinimalSpace",
-			Src:  `sect[]#{}{stmt #{k[2]"p"#{}}true[false];}`,
+			Src:  `sect []#{}{stmt #{k [2]"p"#{}}true [false];}`,
 			Doc: doc().section("sect", mkexprs(), mkmap()).
 				statement("stmt", mkmap("k", mkexprs(2), "p", mkmap()), true, mkexprs(false)).
 				Doc(),


### PR DESCRIPTION
Opening braces are also now permitted inside of barewords. This breaks
any config where there was not a leading space before a '{' or '['
character. The solution is to add a space between the word and '{' or
'[' character to make it unambiguous.

This works by keeping count of how many opening braces and closing
braces are seen in total -- if it's zero, a closing brace is a token
on its own. If it's non-zero, a closing brace is absorbed by the word.
This means you can't write `section{}` without it turning into a word,
but you can write `section {}` and it'll be just fine -- which is
probably preferable, since the version without spaces looks worse.

This also modifies bareword rune absorption (for lack of a better term)
to consume comment runes. So, foo'bar is now a single word "foo'bar",
not "foo" followed by a comment. This is also a case where you can't
compress everything down by removing spaces where possible but the case
it breaks also looks worse, so I prefer it.

Also adds a single ported test case for 0e0 and 0e123 and so on.