### PR TITLE
Test for and fix nil WalkError.Node from Walk

### DIFF
--- a/walk_test.go
+++ b/walk_test.go
@@ -326,6 +326,22 @@ func TestWalkMapper(t *testing.T) {
 	}
 }
 
+func TestMapDelete(t *testing.T) {
+	const DocSource = `stmt 1; section arg {}`
+
+	defer setlogf(t)()
+
+	doc := mustParseNamed(t, "root.conf", DocSource)
+	err := Walk(doc, mapFunc(func(Node) (Node, error) { return nil, nil }))
+	if err != nil {
+		t.Fatalf("err = %v; want nil", err)
+	}
+
+	if got := doc.Children; len(got) != 0 {
+		t.Fatalf("children = %#v; want an empty slice", got)
+	}
+}
+
 func TestMapError(t *testing.T) {
 	const wantErrMessage = `[1:1:0] root.conf: stmt in main: expected error`
 	const DocSource = `stmt 1; section arg {}`
@@ -333,6 +349,8 @@ func TestMapError(t *testing.T) {
 	defer setlogf(t)()
 
 	doc := mustParseNamed(t, "root.conf", DocSource)
+	doc.Children = append([]Node{nil}, doc.Children...)
+
 	wantErr := errors.New("expected error")
 	err := Walk(doc, mapFunc(func(Node) (Node, error) { return nil, wantErr }))
 


### PR DESCRIPTION
This adds a test to confirm that a WalkError returned from Walk(), when
produced by a WalkMapper that returns a nil node and error, panics when
inspected.

This doesn't address WalkErrors panicking on their own since it's
necessary for WalkError.Node to be non-nil.

This is fixed by ensuring that:

1. Walk will skip nil children. It's impossible to map a child that's already nil -- it doesn't exist, so an error can't be produced from it either.
2. Walk uses the mapped child, not the result of the mapping, if Map returns an error. This guarantees that the child described in the error is not nil.

Fixes #12.