### PR TITLE
Switch comment lexing to // instead of quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ a semicolon (;):
     enable-gophers;
     enable-gophers yes;
     enable-gophers yes with-butter;
-    ; ' This line doesn't have a statement -- a semicolon on its own is
-      ' an empty statement and does nothing.
+    ; // This line doesn't have a statement -- a semicolon on its own is
+      // an empty statement and does nothing.
 
 
 ### Sections
@@ -101,7 +101,7 @@ further sections or statements:
 
     outer-section {
         inner-section /some/path {
-            ' ...
+            // ...
         }
 
         enable-gophers yes;
@@ -119,10 +119,12 @@ Parameters must be one of the types described below.
 
 ### Comments
 
-A comment begins with an apostrophe and extends to the nearest line
-ending (a linefeed / 0x0A byte):
+A comment begins with two forward slashes (`//`) and extends to the
+nearest line ending (a linefeed / "\n" / 0x0A byte):
 
-    ' This is a comment
+    // This is a comment
+    //This is also a comment
+    this// is not a comment;
 
 Comments are not included in the parsed AST and may not be used to
 influence configuration.
@@ -140,11 +142,11 @@ Integers can be written in base 10, 16, 8, and 2, as well as arbitrary
 bases in the range of 2-36:
 
     base-10 12345;
-    base-16 0x70f; ' 1807
-    base-8  0712;  ' 458
-    base-2  0b101; ' 5
-    base-3  3#210; ' 21
-    base-36 36#zz; ' 1295
+    base-16 0x70f; // 1807
+    base-8  0712;  // 458
+    base-2  0b101; // 5
+    base-3  3#210; // 21
+    base-36 36#zz; // 1295
 
 Integers are arbitarily long and represented as a `*big.Int`.
 
@@ -153,8 +155,8 @@ Integers are arbitarily long and represented as a `*big.Int`.
 Floats are written either as integers with exponents or decimal numbers
 (with optional exponent):
 
-    float-decimal   1.23456;    ' positive
-    float-exponent  -123456e-5; ' negative
+    float-decimal   1.23456;    // positive
+    float-exponent  -123456e-5; // negative
     float-big       1.23456789e200;
 
 Floats are represented using a `*big.Float`. Precision can be adjusted
@@ -166,8 +168,8 @@ DefaultPrecision.
 Rationals are expressed as numerator/denominator, similar to lisps. It
 is illegal to use a denominator of zero (0):
 
-    rational -5/40; ' -1/8
-    rational 0/40;  ' 0/1
+    rational -5/40; // -1/8
+    rational 0/40;  // 0/1
 
 Rationals are represented using a `*big.Rat`.
 
@@ -180,8 +182,8 @@ beginning with a period as Go does (e.g., ".5s" -- this has to be
 written as "0.5s" in codf). As with Go, it's valid to use "µs" or "us"
 for microseconds.
 
-    durations 0s -1s 1h 500ms;  ' 0s -1s 1h0m0s 500ms
-    decimals  0.5us 0.5s 0.5ms; ' 500ns 500ms 500µs
+    durations 0s -1s 1h 500ms;  // 0s -1s 1h0m0s 500ms
+    decimals  0.5us 0.5s 0.5ms; // 500ns 500ms 500µs
 
 Durations are represented using `time.Duration`.
 
@@ -197,9 +199,9 @@ contrast to Go, newlines in double-quoted strings are permitted without
 escaping them.
 
     simple-string "foobar";
-    escapes       "foo\nbar"; ' "foo\nbar"
+    escapes       "foo\nbar"; // "foo\nbar"
     newline       "foo
-    bar";                     ' "foo\nbar"
+    bar";                     // "foo\nbar"
 
 ##### Raw strings 
 Raw strings are surrounded by backquotes (or backticks -- the "`"
@@ -207,9 +209,9 @@ character). Like Go raw string literals, raw strings can contain almost
 anything. Unlike Go raw string literals, a backquote can be escaped
 inside of a raw string by writing two of them: "``". For example:
 
-    empty           ``;           ' ""
-    with-quotes     `"foobar"`;   ' "\"foobar\""
-    with-backquotes ```foobar```; ' "`foobar`"
+    empty           ``;           // ""
+    with-quotes     `"foobar"`;   // "\"foobar\""
+    with-backquotes ```foobar```; // "`foobar`"
 
 ##### Barewords
 Barewords are unquoted strings and usually more convenient than other
@@ -221,11 +223,11 @@ semicolons, braces, pound, and plus/minus. The rest of a bareword may
 contain decimal numbers, pound, and plus/minus -- semicolons, braces,
 and quotes are still reserved.
 
-    leading-dot .dot;           ' ".dot"
-    symbols     $^--;           ' "$^--"
-    slashes     /foo/bar;       ' "/foo/bar"
-    commas      Hello, World;   ' "Hello," "World" -- two strings
-    unicode     こんにちは世界; ' "こんにちは世界"
+    leading-dot .dot;           // ".dot"
+    symbols     $^--;           // "$^--"
+    slashes     /foo/bar;       // "/foo/bar"
+    commas      Hello, World;   // "Hello," "World" -- two strings
+    unicode     こんにちは世界; // "こんにちは世界"
 
 It is not possible to write a bareword that uses a boolean keyword
 except as a statement name (described below).
@@ -248,8 +250,8 @@ Booleans can be represented using the following values:
 All keywords can be written in lowercase, uppercase, or titlecase. For
 example:
 
-    t-values YES True true; ' true true true
-    f-values FALSE No no;   ' false false false
+    t-values YES True true; // true true true
+    f-values FALSE No no;   // false false false
 
 Other case combinations are not valid (i.e., booleans keywords
 case-sensitive).
@@ -297,9 +299,9 @@ by a VALUE (separated by a space). For example:
 
     empty-map #{};
     normal-map #{
-        ' Key    Value
-        foo      1234      ' "foo" => 1234
-        "bar"    #/baz/    ' "bar"  => #/baz/
+        // Key    Value
+        foo      1234      // "foo" => 1234
+        "bar"    #/baz/    // "bar"  => #/baz/
     };
 
 Map keys must be strings, either bare or quoted. If a key occurs more

--- a/_test/simple-file
+++ b/_test/simple-file
@@ -1,8 +1,12 @@
-' Start
+// Start
 
+// A statement:
 statement word;
 
+// A section
 section "string" {
+	//A comment with no space between the second slash and commentary
+	url https://go.spiff.io/codf;
 }
 
-' End of file
+// End of file

--- a/parser_test.go
+++ b/parser_test.go
@@ -72,7 +72,7 @@ func TestParseAST(t *testing.T) {
 		},
 		{
 			Name: "EmptyArrayMap",
-			Src:  `foo 1 { bar [] #{}; } map #{} [];' eof`,
+			Src:  `foo 1 { bar [] #{}; } map #{} [];// eof`,
 			Doc: doc().section("foo", 1).
 				statement("bar", []ExprNode{}, mkmap()).
 				up().statement("map", mkmap(), []ExprNode{}).
@@ -80,12 +80,12 @@ func TestParseAST(t *testing.T) {
 		},
 		{
 			Name: "NestedArrayMaps",
-			Src: `foo [' Nested map inside array
-					#{ k [  1       ' integer
-						"2"     ' string
-						three   ' bareword (string)
-						true    ' bool (bareword->bool)
-						` + "`true`" + ` ' raw quote bool
+			Src: `foo [// Nested map inside array
+					#{ k [  1       // integer
+						"2"     // string
+						three   // bareword (string)
+						true    // bool (bareword->bool)
+						` + "`true`" + ` // raw quote bool
 						]
 					   ` + "`raw`" + ` bare
 					}
@@ -121,7 +121,7 @@ func TestParseAST(t *testing.T) {
 					#{} #{k v}
 					[] [v1 v2]
 				{
-					inside Yes YES yes yeS ' Last is always a bareword here
+					inside Yes YES yes yeS // Last is always a bareword here
 						No NO no nO
 						True TRUE true truE
 						False FALSE false falsE;
@@ -159,7 +159,7 @@ func TestParseAST(t *testing.T) {
 		{Fun: mustNotParse, Name: "BadStatementClose", Src: `src`},
 		{Fun: mustNotParse, Name: "BadSectionClose", Src: `src {`},
 		{Fun: mustNotParse, Name: "BadSectionClose", Src: `src {]`},
-		{Fun: mustNotParse, Name: "BadSectionClose", Src: `src { ' comment`},
+		{Fun: mustNotParse, Name: "BadSectionClose", Src: `src { // comment`},
 		{Fun: mustNotParse, Name: "BadSectionClose", Src: `}`},
 		{Fun: mustNotParse, Name: "BadSectionClose", Src: `]`},
 	}
@@ -177,7 +177,7 @@ func TestParseExample(t *testing.T) {
         strip-x-headers yes;
         log-access no;
     }
-    ' keep caches in 64mb of memory
+    // keep caches in 64mb of memory
     cache memory 64mb {
          expire 10m 404;
          expire 1h  301 302;
@@ -253,12 +253,12 @@ func TestParseExpr(t *testing.T) {
 	cases := []testCase{
 		{
 			name: "QuotedString",
-			in:   `  "quoted string"  ' comment ' `,
+			in:   `  "quoted string"  // comment // `,
 			want: mkexpr("quoted string"),
 		},
 		{
 			name: "Raw String",
-			in:   "  `raw string`  ' comment '",
+			in:   "  `raw string`  // comment //",
 			want: mkexpr("raw string"),
 		},
 		{
@@ -378,12 +378,12 @@ func TestParseExpr(t *testing.T) {
 		},
 		{
 			name:    "SpaceComment",
-			in:      "  \n  ' foobar\n   'bar\n\n\t\n",
+			in:      "  \n  // foobar\n   //bar\n\n\t\n",
 			wantErr: true,
 		},
 		{
 			name:    "Comment",
-			in:      "' comment",
+			in:      "// comment",
 			wantErr: true,
 		},
 		{

--- a/walk_test.go
+++ b/walk_test.go
@@ -102,7 +102,7 @@ func TestWalk(t *testing.T) {
 		sendfile no;
 		keepalive_timeout 10s;
 		cache /var/run/sv/cache 3;
-		cache_proxy [200 301 302 404] 5m; ' defaults to cache_proxy [] 0
+		cache_proxy [200 301 302 404] 5m; // defaults to cache_proxy [] 0
 	`))
 
 	t.Run("Valid", func(t *testing.T) {


### PR DESCRIPTION
This is more natural for most folks, though it means you can't have
'//' itself as a word. This isn't really an issue, but is a limitation.
You can, of course, just use "//" to create the same thing. Whether
it's the same thing to the thing walking a config is another matter.

In addition, whitespace tokens now preserve their raw values and
comments have both a raw value (this includes the `//`) and a string
value (no `//`). Comment tokens no longer consume the trailing newline,
meaning that `"//foo\n"` is two tokens: a comment and whitespace.

- Switches comment format from "'comment" to "//comment".

- Unreads the newline (or EOF) following a comment, ensuring that the
  newline following the comment is preserved as a token.

- Retains the run of whitespace for a TWhitespace token in the token's
  Raw field. Ideally, this means that printing the raw value of each
  token, one after the other, will reproduce the input document(s).