### PR TITLE
Implement lexer flags to disable special tokens

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -324,10 +324,6 @@ func (p *Parser) parseStatement(tok Token) (tokenConsumer, error) {
 		TBoolean,
 		TRegexp:
 
-		if tok.Kind == TWord {
-			tok = wordToBool(tok)
-		}
-
 		if err := p.context().(segmentNode).addExpr(&Literal{tok}); err != nil {
 			return nil, err
 		}
@@ -414,21 +410,4 @@ func (e *exprParser) addExpr(expr ExprNode) error {
 	}
 	e.expr = expr
 	return nil
-}
-
-func wordToBool(tok Token) Token {
-	if tok.Kind != TWord {
-		return tok
-	}
-	s, ok := tok.Value.(string)
-	if !ok {
-		return tok
-	}
-	switch s {
-	case "TRUE", "True", "true", "YES", "Yes", "yes":
-		tok.Kind, tok.Value = TBoolean, true
-	case "FALSE", "False", "false", "NO", "No", "no":
-		tok.Kind, tok.Value = TBoolean, false
-	}
-	return tok
 }


### PR DESCRIPTION
This makes some adjustments to the lexer to allow a user to disable
tokens they will never use. So, for example, durations might be
useless, so those can be disabled. All number can be disabled, which
implies durations, rationals, floats, and so on as well.

In order to support boolean lexing, those are no longer part of the
parser's conversion steps and have been moved into the lexer. So,
LexNoBools will produce words instead of boolean values when that's
useful (maybe you have a walk step that understands a very narrow set
of words to be booleans).

There isn't a LexNoInts right now, so you can't disable those without
disabling all numbers. This may be supported in the future.

- Add Flags field to Lexer to hold a LexerFlag value. These are simple
  bit flags -- any additional customization of their behavior should
  come through additional fields.

- Move wordToBool to the lexer so that the lexer is responsible for
  identifying booleans. It was a little weird that the parser was
  responsible for this. The less the parser needs to do to munge tokens
  into an acceptable state, the better.

- Add additional tests to check that the lexer will treat disabled
  tokens as words.

Closes #14.