### PR TITLE
Update xerrors dependency for go 1.13+

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.spiff.io/codf
 
 go 1.12
 
-require golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
+require golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
The snapshot of golang.org/x/xerrors from last May was written when the
authors were expecting `errors.Frame` to land in Go 1.13. It did not,
so that snapshot is busted. Upgrading to the most recent available
xerrors gets us a succesful build on 1.13 and 1.14.